### PR TITLE
ci: fix publishFolder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
-on:
-  push:
-    branches:
-      - main
+on: [push]
 
 jobs:
   release:
@@ -11,13 +8,22 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
+
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - uses: actions/setup-node@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
         with:
-          node-version: '16'
-          cache: 'yarn'
+          node-version: 16.x
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: yarn-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-deps-${{ hashFiles('yarn.lock') }}
 
       - run: yarn install --frozen-lockfile
 
@@ -26,3 +32,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx auto shipit
+      

--- a/auto.config.ts
+++ b/auto.config.ts
@@ -3,7 +3,7 @@ import { AutoRc } from 'auto'
 import { INpmConfig } from '@auto-it/npm'
 
 const npmOptions: INpmConfig = {
-  publishFolder: 'dist',
+  publishFolder: './dist',
 }
 
 export default function rc(): AutoRc {


### PR DESCRIPTION
auto publishFolder needs to be relative. Otherwise, NPM thinks we are publishing the `dist` package. 🙈 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.1--canary.364.3853a07.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@4.1.1--canary.364.3853a07.0
  # or 
  yarn add react-easy-crop@4.1.1--canary.364.3853a07.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
