### PR TITLE
docs: add npm example in development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,13 @@ const CroppedImage = ({ image }) => {
 ## Development
 
 ```shell
-yarn
-yarn start
+yarn && yarn start
+```
+
+or
+
+```shell
+npm install & npm run
 ```
 
 Now, open `http://localhost:3001/index.html` and start hacking!


### PR DESCRIPTION
Add example of how to run development with `npm`

Also, make `yarn` example one command line instead of 2