### PR TITLE
[CI] Add Quality Gate Action

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -26,6 +26,12 @@ jobs:
 
       - name: Create Build
         run: yarn build
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: |
+            dist
 
       - name: Run linting
         run: yarn lint

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,35 @@
+name: Quality Gate
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: yarn-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-deps-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+
+      - name: Create Build
+        run: yarn build
+
+      - name: Run linting
+        run: yarn lint
+
+      - name: Run unit tests
+        run: yarn unit

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -5,7 +5,6 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   quality-gate:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
       - name: Prepare repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.repository == 'ValentinH/react-easy-crop'"
     steps:
       - uses: actions/checkout@v2
 
@@ -32,4 +32,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx auto shipit
-      

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A React component to crop images/videos with easy interactions
 
-[![version][version-badge]][package] [![Monthly downloads][npmstats-badge]][npmstats] ![brotli size][brotli-badge] [![All Contributors](https://img.shields.io/badge/all_contributors-20-green.svg?style=flat-square)](#contributors) [![Build Status][build-badge]][build-page] [![MIT License][license-badge]][license] [![PRs Welcome][prs-badge]][prs] [![Auto Release](https://img.shields.io/badge/release-auto.svg?colorA=888888&colorB=9B065A&label=auto)](https://github.com/intuit/auto)
+[![version][version-badge]][package] [![Monthly downloads][npmstats-badge]][npmstats] ![brotli size][brotli-badge] [![All Contributors](https://img.shields.io/badge/all_contributors-20-green.svg?style=flat-square)](#contributors) [![Build Status][build-badge]][build-page] [![Test Status][test-badge]][test-action] [![MIT License][license-badge]][license] [![PRs Welcome][prs-badge]][prs] [![Auto Release](https://img.shields.io/badge/release-auto.svg?colorA=888888&colorB=9B065A&label=auto)](https://github.com/intuit/auto)
 
 ![react-easy-crop Demo](https://user-images.githubusercontent.com/2678610/41561426-365e7a44-734a-11e8-8e0e-1c04251f53e4.gif)
 
@@ -281,3 +281,5 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 [prs]: http://makeapullrequest.com
 [build-badge]: https://circleci.com/gh/ValentinH/react-easy-crop/tree/main.svg?style=svg
 [build-page]: https://circleci.com/gh/ValentinH/react-easy-crop/tree/main
+[test-badge]: https://github.com/ValentinH/react-easy-crop/actions/workflows/quality-gate.yml/badge.svg
+[test-action]: https://github.com/ValentinH/react-easy-crop/actions/workflows/quality-gate.yml


### PR DESCRIPTION
Add a "quality-gate" GitHub Action that runs `build`, `lint` then `unit test`.
The action can run on push, PR, or manually. 

I added a badge to the read-me but I can't see if it will properly work until it runs on the main repo.

Additional changes: I had to add a condition to the release workflow so that the it wouldn't fail on my fork. 

Next steps:

1. Remove the duplicated workflows from CircleCI
2. Create a Github workflow for Cypress 
3. Add better integration for test results, linting, coverage reporting, etc .. (maybe something like https://danger.systems/js/ )  
