### PR TITLE
Update copy-build-files.js

### DIFF
--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -28,6 +28,7 @@ async function createPackageFile() {
       '.': {
         import: './index.module.js',
         require: './index.js',
+        types: './index.d.ts',
       },
     },
   }


### PR DESCRIPTION
Add "types" to exports to handle issue where typescript wouldn't recognize exported types when using ESM.
