### PR TITLE
Add support for running an srcDoc style iFrame

### DIFF
--- a/cypress/integration/iframe_spec.js
+++ b/cypress/integration/iframe_spec.js
@@ -1,0 +1,22 @@
+describe('Iframed assertions', function () {
+  beforeEach(function () {
+    cy.viewport(1000, 600)
+    cy.visit('/?iframed=true')
+  })
+
+  const getIframeBody = () => {
+    return cy
+      .get('iframe[data-cy="iframe"]')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then(cy.wrap)
+  }
+
+  it('Display the crop area with correct styles applied to the iframe', () => {
+    getIframeBody()
+      .find('.reactEasyCrop_CropArea')
+      .should('exist')
+      .should('have.css', 'color')
+      .and('eq', 'rgba(0, 0, 0, 0.5)')
+  })
+})

--- a/examples/src/iframe.tsx
+++ b/examples/src/iframe.tsx
@@ -39,6 +39,7 @@ export default function Iframe({ children }: Props) {
         ref={iFrameRef}
         srcDoc="<!doctype html>"
         title="test iframed"
+        data-cy="iframe"
       >
         <>{iframeBody && createPortal(children, iframeBody)}</>
       </iframe>

--- a/examples/src/iframe.tsx
+++ b/examples/src/iframe.tsx
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import * as React from 'react'
+
+import './styles.css'
+import { createPortal } from 'react-dom'
+
+export default function Iframe({ children, ...props }) {
+  const [iframeBody, setIframeBody] = React.useState<HTMLElement>()
+
+  const iFrameRef = React.useRef<HTMLIFrameElement>()
+
+  React.useEffect(() => {
+    function setDocumentIfReady() {
+      const { contentDocument } = iFrameRef.current
+      const { readyState, documentElement } = contentDocument
+
+      if (readyState !== 'interactive' && readyState !== 'complete') {
+        return false
+      }
+
+      setIframeBody(documentElement.getElementsByTagName('body')[0])
+
+      return true
+    }
+
+    // Document set with srcDoc is not immediately ready.
+    iFrameRef.current.addEventListener('load', setDocumentIfReady)
+  }, [iFrameRef])
+
+  return (
+    <>
+      <iframe
+        style={{ height: '100vh', width: '100vw' }}
+        {...props}
+        ref={iFrameRef}
+        srcDoc="<!doctype html>"
+        title="test iframed"
+      >
+        {iframeBody && createPortal(children, iframeBody)}
+      </iframe>
+    </>
+  )
+}

--- a/examples/src/iframe.tsx
+++ b/examples/src/iframe.tsx
@@ -1,18 +1,21 @@
-// @ts-nocheck
 import * as React from 'react'
 
 import './styles.css'
 import { createPortal } from 'react-dom'
 
-export default function Iframe({ children, ...props }) {
+interface Props {
+  children: React.ReactNode
+}
+
+export default function Iframe({ children }: Props) {
   const [iframeBody, setIframeBody] = React.useState<HTMLElement>()
 
-  const iFrameRef = React.useRef<HTMLIFrameElement>()
+  const iFrameRef = React.useRef<HTMLIFrameElement>(null)
 
   React.useEffect(() => {
     function setDocumentIfReady() {
-      const { contentDocument } = iFrameRef.current
-      const { readyState, documentElement } = contentDocument
+      const { contentDocument } = iFrameRef.current as HTMLIFrameElement
+      const { readyState, documentElement } = contentDocument as Document
 
       if (readyState !== 'interactive' && readyState !== 'complete') {
         return false
@@ -24,19 +27,20 @@ export default function Iframe({ children, ...props }) {
     }
 
     // Document set with srcDoc is not immediately ready.
-    iFrameRef.current.addEventListener('load', setDocumentIfReady)
+    if (iFrameRef.current) {
+      iFrameRef.current.addEventListener('load', setDocumentIfReady)
+    }
   }, [iFrameRef])
 
   return (
     <>
       <iframe
         style={{ height: '100vh', width: '100vw' }}
-        {...props}
         ref={iFrameRef}
         srcDoc="<!doctype html>"
         title="test iframed"
       >
-        {iframeBody && createPortal(children, iframeBody)}
+        <>{iframeBody && createPortal(children, iframeBody)}</>
       </iframe>
     </>
   )

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import debounce from 'lodash/debounce'
 import Cropper, { Area, Point } from '../../src/index'
 import './styles.css'
+import Iframe from './iframe'
 
 const TEST_IMAGES = {
   '/images/dog.jpeg': 'Landscape',
@@ -38,6 +39,7 @@ type State = {
   initialCroppedAreaPixels: Area | undefined
   requireCtrlKey: boolean
   requireMultiTouch: boolean
+  iframed: boolean
 }
 
 const hashNames = ['imageSrc', 'hashType', 'x', 'y', 'width', 'height', 'rotation'] as const
@@ -66,6 +68,7 @@ class App extends React.Component<{}, State> {
     let initialCroppedAreaPixels: Area | undefined = undefined
     let hashType: HashType = 'percent'
     let imageSrc = imageSrcFromQuery
+    const query = new URLSearchParams(window.location.search)
 
     if (window && !urlArgs.setInitialCrop) {
       const hashArray = window.location.hash.slice(1).split(',')
@@ -119,6 +122,7 @@ class App extends React.Component<{}, State> {
       initialCroppedAreaPixels,
       requireCtrlKey: false,
       requireMultiTouch: false,
+      iframed: !!query.get('iframed'),
     }
   }
 
@@ -175,6 +179,33 @@ class App extends React.Component<{}, State> {
   }
 
   render() {
+    if (this.state.iframed) {
+      return (
+        <Iframe>
+          <div className="crop-container">
+            <Cropper
+              image={this.state.imageSrc}
+              crop={this.state.crop}
+              rotation={this.state.rotation}
+              zoom={this.state.zoom}
+              aspect={this.state.aspect}
+              cropShape={this.state.cropShape}
+              showGrid={this.state.showGrid}
+              zoomSpeed={this.state.zoomSpeed}
+              restrictPosition={this.state.restrictPosition}
+              onCropChange={this.onCropChange}
+              onRotationChange={this.onRotationChange}
+              onCropComplete={this.onCropComplete}
+              onCropAreaChange={this.onCropAreaChange}
+              onZoomChange={this.onZoomChange}
+              onInteractionStart={this.onInteractionStart}
+              onInteractionEnd={this.onInteractionEnd}
+            />
+          </div>
+        </Iframe>
+      )
+    }
+
     return (
       <div className="App">
         <div className="controls">

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -62,6 +62,8 @@ export type CropperProps = {
   setMediaSize?: (size: MediaSize) => void
   setCropSize?: (size: Size) => void
   nonce?: string
+  parentDocument?: any
+  parentWindow?: any
 }
 
 type State = {
@@ -103,6 +105,8 @@ class Cropper extends React.Component<CropperProps, State> {
   rafDragTimeout: number | null = null
   rafPinchTimeout: number | null = null
   wheelTimer: number | null = null
+  currentDoc: any = document
+  currentWindow: any = window
 
   state: State = {
     cropSize: null,
@@ -110,8 +114,11 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.computeSizes)
+    this.currentDoc = this.props.parentDocument ? this.props.parentDocument : document
+    this.currentWindow = this.props.parentWindow ? this.props.parentWindow : window
+
     if (this.containerRef) {
+      this.currentWindow.addEventListener('resize', this.computeSizes)
       this.props.zoomWithScroll &&
         this.containerRef.addEventListener('wheel', this.onWheel, { passive: false })
       this.containerRef.addEventListener('gesturestart', this.preventZoomSafari)
@@ -119,13 +126,15 @@ class Cropper extends React.Component<CropperProps, State> {
     }
 
     if (!this.props.disableAutomaticStylesInjection) {
-      this.styleRef = document.createElement('style')
-      this.styleRef.setAttribute('type', 'text/css')
+      this.styleRef = this.currentDoc.createElement('style')
+      this.styleRef?.setAttribute('type', 'text/css')
       if (this.props.nonce) {
-        this.styleRef.setAttribute('nonce', this.props.nonce)
+        this.styleRef?.setAttribute('nonce', this.props.nonce)
       }
-      this.styleRef.innerHTML = cssStyles
-      document.head.appendChild(this.styleRef)
+      if (this.styleRef) {
+        this.styleRef.innerHTML = cssStyles
+      }
+      this.currentDoc.head.appendChild(this.styleRef)
     }
 
     // when rendered via SSR, the image can already be loaded and its onLoad callback will never be called
@@ -144,7 +153,7 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.computeSizes)
+    this.currentWindow?.removeEventListener('resize', this.computeSizes)
     if (this.containerRef) {
       this.containerRef.removeEventListener('gesturestart', this.preventZoomSafari)
       this.containerRef.removeEventListener('gesturechange', this.preventZoomSafari)
@@ -191,10 +200,10 @@ class Cropper extends React.Component<CropperProps, State> {
   preventZoomSafari = (e: Event) => e.preventDefault()
 
   cleanEvents = () => {
-    document.removeEventListener('mousemove', this.onMouseMove)
-    document.removeEventListener('mouseup', this.onDragStopped)
-    document.removeEventListener('touchmove', this.onTouchMove)
-    document.removeEventListener('touchend', this.onDragStopped)
+    this.currentDoc?.removeEventListener('mousemove', this.onMouseMove)
+    this.currentDoc?.removeEventListener('mouseup', this.onDragStopped)
+    this.currentDoc?.removeEventListener('touchmove', this.onTouchMove)
+    this.currentDoc?.removeEventListener('touchend', this.onDragStopped)
   }
 
   clearScrollEvent = () => {
@@ -327,7 +336,7 @@ class Cropper extends React.Component<CropperProps, State> {
         naturalWidth,
         naturalHeight,
       }
-      
+
       // set media size in the parent
       if (this.props.setMediaSize) {
         this.props.setMediaSize(this.mediaSize)
@@ -372,8 +381,8 @@ class Cropper extends React.Component<CropperProps, State> {
 
   onMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     e.preventDefault()
-    document.addEventListener('mousemove', this.onMouseMove)
-    document.addEventListener('mouseup', this.onDragStopped)
+    this.currentDoc?.addEventListener('mousemove', this.onMouseMove)
+    this.currentDoc?.addEventListener('mouseup', this.onDragStopped)
     this.onDragStart(Cropper.getMousePoint(e))
   }
 
@@ -384,8 +393,8 @@ class Cropper extends React.Component<CropperProps, State> {
       return
     }
 
-    document.addEventListener('touchmove', this.onTouchMove, { passive: false }) // iOS 11 now defaults to passive: true
-    document.addEventListener('touchend', this.onDragStopped)
+    this.currentDoc?.addEventListener('touchmove', this.onTouchMove, { passive: false }) // iOS 11 now defaults to passive: true
+    this.currentDoc?.addEventListener('touchend', this.onDragStopped)
 
     if (e.touches.length === 2) {
       this.onPinchStart(e)
@@ -411,9 +420,9 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   onDrag = ({ x, y }: Point) => {
-    if (this.rafDragTimeout) window.cancelAnimationFrame(this.rafDragTimeout)
+    if (this.rafDragTimeout) this.currentWindow?.cancelAnimationFrame(this.rafDragTimeout)
 
-    this.rafDragTimeout = window.requestAnimationFrame(() => {
+    this.rafDragTimeout = this.currentWindow?.requestAnimationFrame(() => {
       if (!this.state.cropSize) return
       if (x === undefined || y === undefined) return
       const offsetX = x - this.dragStartPosition.x
@@ -456,8 +465,8 @@ class Cropper extends React.Component<CropperProps, State> {
     const center = getCenter(pointA, pointB)
     this.onDrag(center)
 
-    if (this.rafPinchTimeout) window.cancelAnimationFrame(this.rafPinchTimeout)
-    this.rafPinchTimeout = window.requestAnimationFrame(() => {
+    if (this.rafPinchTimeout) this.currentWindow?.cancelAnimationFrame(this.rafPinchTimeout)
+    this.rafPinchTimeout = this.currentWindow?.requestAnimationFrame(() => {
       const distance = getDistanceBetweenPoints(pointA, pointB)
       const newZoom = this.props.zoom * (distance / this.lastPinchDistance)
       this.setNewZoom(newZoom, center, { shouldUpdatePosition: false })
@@ -488,7 +497,7 @@ class Cropper extends React.Component<CropperProps, State> {
     if (this.wheelTimer) {
       clearTimeout(this.wheelTimer)
     }
-    this.wheelTimer = window.setTimeout(
+    this.wheelTimer = this.currentWindow?.setTimeout(
       () => this.setState({ hasWheelJustStarted: false }, () => this.props.onInteractionEnd?.()),
       250
     )

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -114,6 +114,7 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   componentDidMount() {
+    console.log('running fork - v1')
     this.currentDoc = this.props.parentDocument ? this.props.parentDocument : document
     this.currentWindow = this.props.parentWindow ? this.props.parentWindow : window
 

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -132,9 +132,7 @@ class Cropper extends React.Component<CropperProps, State> {
       if (this.props.nonce) {
         this.styleRef.setAttribute('nonce', this.props.nonce)
       }
-      if (this.styleRef) {
-        this.styleRef.innerHTML = cssStyles
-      }
+      this.styleRef.innerHTML = cssStyles
       this.currentDoc.head.appendChild(this.styleRef)
     }
 


### PR DESCRIPTION
As [noted here](https://github.com/WordPress/gutenberg/issues/38557), there are some instances where iFraming `react-easy-crop` causes the styles and events to be lost as they are always attached to the global `window` and `document`.

This PR changes the `Cropper` `componentDidMount` method to instead get the `document` and `window` references from the current `containerRef` if it is defined. 

The PR also adds an iFramed version of the component to the example page to allow for testing. This can be accessed via `http://localhost:3001/?iframed=true`.


