### PR TITLE
Add package.json css export

### DIFF
--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -31,8 +31,8 @@ async function createPackageFile() {
         types: './index.d.ts',
       },
       './react-easy-crop.css': {
-        'import': './react-easy-crop.css',
-        'require': './react-easy-crop.css'
+        import: './react-easy-crop.css',
+        require: './react-easy-crop.css'
       }
     },
   }

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -30,6 +30,10 @@ async function createPackageFile() {
         require: './index.js',
         types: './index.d.ts',
       },
+      './react-easy-crop.css': {
+        'import': './react-easy-crop.css',
+        'require': './react-easy-crop.css'
+      }
     },
   }
   const buildPath = path.resolve(__dirname, '../dist/package.json')


### PR DESCRIPTION
# Purpose of the Pull Request
## Problem
Using vite bundler in a monorepo setup with the `disableAutomaticStylesInjection`  set to true, I was facing an issue where I couldn't import the `react-easy-crop.css` using a reference to the package, like `import 'react-easy-crop/react-easy-crop.css'`. Instead I had to import this file from the node_modules, which is not ideal and actually break if the node_modules location change.

## Solution
Adding an export statement in the package.json to be able to import the `react-easy-crop.css` by referencing the package name.
