### PR TITLE
fix: recompute size when objectFit is changed

### DIFF
--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -191,6 +191,8 @@ class Cropper extends React.Component<CropperProps, State> {
       this.recomputeCropPosition()
     } else if (prevProps.aspect !== this.props.aspect) {
       this.computeSizes()
+    } else if (prevProps.objectFit !== this.props.objectFit) {
+      this.computeSizes()
     } else if (prevProps.zoom !== this.props.zoom) {
       this.recomputeCropPosition()
     } else if (


### PR DESCRIPTION
Fixes #481

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.1--canary.483.2194639.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@5.0.1--canary.483.2194639.0
  # or 
  yarn add react-easy-crop@5.0.1--canary.483.2194639.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
