### PR TITLE
fix(crop-area): recalculate sizes on media objectFit change

### DIFF
--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -67,6 +67,7 @@ export type CropperProps = {
 type State = {
   cropSize: Size | null
   hasWheelJustStarted: boolean
+  mediaObjectFit: String | undefined
 }
 
 const MIN_ZOOM = 1
@@ -121,6 +122,7 @@ class Cropper extends React.Component<CropperProps, State> {
   state: State = {
     cropSize: null,
     hasWheelJustStarted: false,
+    mediaObjectFit: undefined
   }
 
   componentDidMount() {
@@ -217,6 +219,11 @@ class Cropper extends React.Component<CropperProps, State> {
     }
     if (prevProps.video !== this.props.video) {
       this.videoRef.current?.load()
+    }
+
+    const objectFit = this.getObjectFit();
+    if (objectFit !== this.state.mediaObjectFit) {
+      this.setState({mediaObjectFit: objectFit}, this.computeSizes)
     }
   }
 
@@ -350,8 +357,7 @@ class Cropper extends React.Component<CropperProps, State> {
       let renderedMediaSize: Size
 
       if (isMediaScaledDown) {
-        const objectFit = this.getObjectFit()
-        switch (objectFit) {
+        switch (this.state.mediaObjectFit) {
           default:
           case 'contain':
             renderedMediaSize =
@@ -737,7 +743,7 @@ class Cropper extends React.Component<CropperProps, State> {
       classes: { containerClassName, cropAreaClassName, mediaClassName },
     } = this.props
 
-    const objectFit = this.getObjectFit()
+    const objectFit = this.state.mediaObjectFit;
 
     return (
       <div


### PR DESCRIPTION
Hello @ValentinH!

I've faced an issue with crop area size computation on picture changes with obejct-fit: "cover".

## Pre requirements
- Use round cropper with fixed size 

Cropper properties
```
object-fit: "cover",
aspect: 1,
cropShape: "round",
```
Container css properties:
```
width: 500px,
height: 500px
```

## Steps to reproduce:
- Choose Horizontal Big image (all sides > 500px)
- Change image to Vertical Small (all sides < 500px)

(Same for Vertical Big - Horizontal Small image pair)

## Expected behaviour

Crop area is 500x500
![Screenshot 2023-12-14 at 15 04 12](https://github.com/ValentinH/react-easy-crop/assets/45610004/e5370c56-3e15-4c4e-b518-2714515d60c0)

## Observed behaviour

Crop area is 250x250
![Screenshot 2023-12-14 at 14 55 36](https://github.com/ValentinH/react-easy-crop/assets/45610004/858150fc-5e82-423a-a32f-cffc4265a1fa)

To fix the issue I've moved the getObjectFIt() result value into state and added callback to recalculateSize() on this state value change.

Issue code example: https://codesandbox.io/p/sandbox/react-easy-crop-demo-forked-6xh2m2?file=%2Fsrc%2Findex.js
Fix code example: https://codesandbox.io/p/sandbox/react-easy-crop-forked-vzrfyk?file=%2Fsrc%2Findex.js
