### PR TITLE
chore: improve package exports

### DIFF
--- a/bili.config.ts
+++ b/bili.config.ts
@@ -23,7 +23,7 @@ const config: Config = {
       config.output.fileName = 'umd/react-easy-crop[min].js'
     }
     if (format === 'esm') {
-      config.output.fileName = '[name].module.js'
+      config.output.fileName = '[name].module.mjs'
     }
     return config
   },

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -22,7 +22,7 @@ async function createPackageFile() {
     exports: {
       '.': {
         import: {
-          types: './index.d.ts',
+          types: './index.d.mts',
           default: './index.module.mjs',
         },
         require: {

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -22,7 +22,7 @@ async function createPackageFile() {
     exports: {
       '.': {
         import: {
-          types: './index.d.mts',
+          types: './index.module.d.mts',
           default: './index.module.mjs',
         },
         require: {

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -17,18 +17,18 @@ async function createPackageFile() {
     jest: undefined,
     'lint-staged': undefined,
     main: './index.js',
-    'umd:main': './umd/react-easy-crop.js',
-    unpkg: './umd/react-easy-crop.js',
-    jsdelivr: './umd/react-easy-crop.js',
-    module: './index.module.js',
-    'jsnext:main': './index.module.js',
-    'react-native': './index.module.js',
+    module: './index.module.mjs',
     types: './index.d.ts',
     exports: {
       '.': {
-        import: './index.module.js',
-        require: './index.js',
-        types: './index.d.ts',
+        import: {
+          types: './index.d.ts',
+          default: './index.module.mjs',
+        },
+        require: {
+          types: './index.d.ts',
+          default: './index.js',
+        },
       },
       './react-easy-crop.css': {
         import: './react-easy-crop.css',
@@ -50,6 +50,7 @@ async function run() {
       { from: './README.md' },
       { from: './LICENSE' },
       { from: './src/styles.css', to: 'react-easy-crop.css' },
+      { from: './dist/index.d.ts', to: './dist/index.module.d.mts' },
     ].map((file) => copyFile(file))
   )
   await createPackageFile()


### PR DESCRIPTION
This is an attempt to fix #490.

However, https://arethetypeswrong.github.io/ is still not fully happy about it. The problem is that we are using `bili` to build the library and it's not maintain anymore. Ideally, we need to migrate to a fully new setup to build this lib but I'm a bit lost at the moment (and I hate this topic!).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.7--canary.527.1aad632.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@5.0.7--canary.527.1aad632.0
  # or 
  yarn add react-easy-crop@5.0.7--canary.527.1aad632.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
