### PR TITLE
🐛fix: make the prop CropperProps.keyboardStep not required

### DIFF
--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -62,7 +62,7 @@ export type CropperProps = {
   setMediaSize?: (size: MediaSize) => void
   setCropSize?: (size: Size) => void
   nonce?: string
-  keyboardStep: number
+  keyboardStep?: number
 }
 
 type State = {

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -731,7 +731,7 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const { crop, onCropChange, keyboardStep, zoom, rotation } = this.props
+    const { crop, onCropChange, keyboardStep = Cropper.defaultProps.keyboardStep, zoom, rotation } = this.props
     let step = keyboardStep
 
     if (!this.state.cropSize) return


### PR DESCRIPTION
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/91c1dc4c-3fa8-4be3-96d6-a069ee93ef10" />

Prop of `CropperProps.keyboardStep`  is not required in the doc, change it into optional.