### PR TITLE
hotfix: Fix duplicate state updates

### DIFF
--- a/cypress/integration/basic_spec.js
+++ b/cypress/integration/basic_spec.js
@@ -35,4 +35,22 @@ describe('Basic assertions', function () {
     cy.get('#horizontal-center-button').click()
     cy.get('#crop-area-x').contains('15')
   })
+
+  it('should preserve crop position after window resize', function () {
+    cy.get('[data-testid=container]').dragAndDrop({ x: 1000, y: 0 })
+    cy.get('#crop-area-x').then(($el) => {
+      const initialX = $el.text()
+      cy.setViewportStable(500, 500)
+      cy.setViewportStable(1000, 1000)
+      cy.get('#crop-area-x').should('contain', initialX)
+    })
+    cy.percySnapshot()
+  })
+
+  it('should keep crop area centered when switching orientation', function () {
+    cy.get('#crop-area-x').should('contain', '15')
+    cy.get('#picture-select').select('Portrait')
+    cy.get('#crop-area-y').should('contain', '25')
+    cy.percySnapshot()
+  })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,3 +34,19 @@ Cypress.Commands.add('rotate', { prevSubject: 'element' }, (subject, options) =>
     .trigger('touchmove', { touches: moveTouches })
     .trigger('touchend')
 })
+
+Cypress.Commands.add('setViewportStable', (width, height) => {
+  cy.viewport(width, height)
+  cy.window().should((win) => {
+    expect(win.innerWidth).to.eq(width)
+    expect(win.innerHeight).to.eq(height)
+  })
+  cy.window().then(
+    (win) =>
+    new Cypress.Promise((resolve) => {
+      win.requestAnimationFrame(() => {
+        win.requestAnimationFrame(() => resolve())
+      })
+    })
+  )
+})

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -298,7 +298,11 @@ class App extends React.Component<{}, State> {
             <div>
               <label>
                 Picture:
-                <select value={this.state.imageSrc} onChange={this.onImageSrcChange}>
+                <select
+                  id="picture-select"
+                  value={this.state.imageSrc}
+                  onChange={this.onImageSrcChange}
+                >
                   {Object.entries(TEST_IMAGES).map(([key, value]) => (
                     <option key={key} value={key}>
                       {value}


### PR DESCRIPTION
This PR removes an unintended double setState sequence introduced in #622 that could trigger duplicate renders and callbacks (onCropChange, onZoomChange, onCropComplete) whenever cropSize changes.