### PR TITLE
fix: ESM build

### DIFF
--- a/bili.config.ts
+++ b/bili.config.ts
@@ -23,7 +23,7 @@ const config: Config = {
       config.output.fileName = 'umd/react-easy-crop[min].js'
     }
     if (format === 'esm') {
-      config.output.fileName = '[name].module.js'
+      config.output.fileName = '[name].module.mjs'
     }
     return config
   },

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -21,8 +21,8 @@ async function createPackageFile() {
     unpkg: './umd/react-easy-crop.js',
     jsdelivr: './umd/react-easy-crop.js',
     module: './index.module.mjs',
-    'jsnext:main': './index.module.mjs',
     'react-native': './index.module.mjs',
+    'jsnext:main': './index.module.mjs',
     types: './index.d.ts',
     exports: {
       '.': {

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -20,13 +20,13 @@ async function createPackageFile() {
     'umd:main': './umd/react-easy-crop.js',
     unpkg: './umd/react-easy-crop.js',
     jsdelivr: './umd/react-easy-crop.js',
-    module: './index.module.js',
-    'jsnext:main': './index.module.js',
-    'react-native': './index.module.js',
+    module: './index.module.mjs',
+    'jsnext:main': './index.module.mjs',
+    'react-native': './index.module.mjs',
     types: './index.d.ts',
     exports: {
       '.': {
-        import: './index.module.js',
+        import: './index.module.mjs',
         require: './index.js',
         types: './index.d.ts',
       },


### PR DESCRIPTION
The ESM build is not usable in strict tools because the file is named `index.module.js` and the package.json indicates that `.js` files are CommonJS rather than ESM.

It seems a pretty simple change to the build configuration to have it be named `index.module.mjs` instead.

Fixes #490