### PR TITLE
fix: prevent NaN crop when previousCropSize.x/y is zero

### DIFF
--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -734,7 +734,7 @@ class Cropper extends React.Component<CropperProps, State> {
     let adjustedCrop = this.props.crop
 
     // Only scale if we're initialized and this is a legitimate resize
-    if (this.isInitialized && this.previousCropSize) {
+    if (this.isInitialized && this.previousCropSize?.width && this.previousCropSize?.height) {
       const sizeChanged =
         Math.abs(this.previousCropSize.width - this.state.cropSize.width) > 1e-6 ||
         Math.abs(this.previousCropSize.height - this.state.cropSize.height) > 1e-6


### PR DESCRIPTION
Fixes #634

When the cropper is inside an animated modal, there was an edge case where the `previousCropSize`  was `{width: 0, height: 0}`  leading to the computed crop being set to `{x: NaN, y: NaN}` 🙈