### PR TITLE
Update pnpm 11 configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "author": "Valentin Hervieu <valentin@hervi.eu>",
   "license": "MIT",
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.5.2",
   "sideEffects": false,
   "scripts": {
     "start": "vite ./examples --port 3001 --clearScreen false",
@@ -92,14 +92,6 @@
     "typescript": "^6.0.3",
     "vite": "^6.4.2",
     "vitest": "^4.1.8"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@percy/core",
-      "cypress",
-      "esbuild",
-      "husky"
-    ]
   },
   "lint-staged": {
     "*.+(ts|tsx|js|css)": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+allowBuilds:
+  '@percy/core': true
+  cypress: true
+  esbuild: true
+  husky: true
+onlyBuiltDependencies:
+  - '@percy/core'
+  - cypress
+  - esbuild
+  - husky

--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -23,7 +23,6 @@ async function createPackageFile() {
         'react-easy-crop.css': ['./react-easy-crop.css.d.ts'],
       },
     },
-    pnpm: undefined,
     packageManager: undefined,
     exports: {
       '.': {


### PR DESCRIPTION
## Summary
- bump the package manager pin to pnpm 11.5.2
- move pnpm build-script approvals out of package.json and into pnpm-workspace.yaml
- drop the now-unneeded published package cleanup for the legacy pnpm field

## Why
Homebrew pnpm 11 hangs/warns in this repo when it sees the old package.json pnpm config. Moving the settings to pnpm's current config location lets native pnpm start cleanly and read the approved build dependencies.

## Verification
- /opt/homebrew/bin/pnpm --version
- /opt/homebrew/bin/pnpm config get only-built-dependencies
- /opt/homebrew/bin/pnpm install
- /opt/homebrew/bin/pnpm type-check
- /opt/homebrew/bin/pnpm build
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.0.1--canary.648.1db53c8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@6.0.1--canary.648.1db53c8.0
  # or 
  yarn add react-easy-crop@6.0.1--canary.648.1db53c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
