### PR TITLE
Fix media sizing with CSS resets

### DIFF
--- a/cypress/integration/basic_spec.js
+++ b/cypress/integration/basic_spec.js
@@ -16,6 +16,17 @@ describe('Basic assertions', function () {
     cy.percySnapshot()
   })
 
+  it('keeps wide images correctly sized with global CSS reset rules', function () {
+    cy.document().then((doc) => {
+      const style = doc.createElement('style')
+      style.textContent = 'img, video { max-width: 100%; }'
+      doc.head.appendChild(style)
+    })
+
+    cy.get('img').should('have.css', 'width', '1000px')
+    assertCssNumberCloseTo('img', 'height', 523.546875)
+  })
+
   it('Display tall images and set the image and cropper with correct dimension', function () {
     cy.visit('/?img=/images/cat.jpeg')
     cy.get('img').should('have.css', 'width', '338.4375px')

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,7 @@
 .reactEasyCrop_Image,
 .reactEasyCrop_Video {
   will-change: transform; /* this improves performances and prevent painting issues on iOS Chrome */
+  max-width: unset; /* prevent global img/video reset rules from constraining the cropper media */
 }
 
 .reactEasyCrop_Contain {


### PR DESCRIPTION
Closes #608. Adds max-width: unset to crop media so global img/video reset rules from frameworks do not constrain wide images, and adds Cypress coverage for img, video { max-width: 100%; }. Tests: pnpm lint; pnpm unit; pnpm exec start-server-and-test "pnpm start" http://localhost:3001 "pnpm cy:run -- --spec cypress/integration/basic_spec.js"; pnpm build.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.0.1--canary.649.e8aa4d1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@6.0.1--canary.649.e8aa4d1.0
  # or 
  yarn add react-easy-crop@6.0.1--canary.649.e8aa4d1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
