### PR TITLE
Fix generated CSS type declaration

### DIFF
--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -52,7 +52,7 @@ async function createPackageFile() {
 
 async function createCssTypesFile() {
   const buildPath = path.resolve(__dirname, '../dist/react-easy-crop.css.d.ts')
-  await fse.writeFile(buildPath, 'export {}\\n', 'utf8')
+  await fse.writeFile(buildPath, 'export {}\n', 'utf8')
   console.log(`Created ${buildPath}`)
 }
 


### PR DESCRIPTION
## Summary
- fix the generated `react-easy-crop.css.d.ts` file to write a real newline after `export {}`
- prevents the published CSS declaration from containing a literal `\n` sequence

Fixes #650.

## Reproduction
Created a blank TypeScript project with `react-easy-crop@6.0.1` and imported `react-easy-crop/react-easy-crop.css`.

Published 6.0.1 contains these bytes in `react-easy-crop.css.d.ts`:

```text
export {}\n
```

Running `./node_modules/.bin/tsc --noEmit` fails with:

```text
TS1127: Invalid character.
```

## Verification
- `pnpm build`
- `od -c dist/react-easy-crop.css.d.ts` shows `export {}` followed by a real newline
- packed `dist` and installed it in the blank repro project
- `./node_modules/.bin/tsc --noEmit` passes in the repro project
- `./node_modules/.bin/vite build` passes in the repro project
- ran the repro app in Vite dev mode, verified the cropper is constrained to its container, drag updates crop state/image transform, and there are no browser console errors
- `pnpm type-check`
