### PR TITLE
fix: debounce onCropComplete/onCropAreaChange during resize bursts

### DIFF
--- a/cypress/integration/basic_spec.js
+++ b/cypress/integration/basic_spec.js
@@ -70,4 +70,48 @@ describe('Basic assertions', function () {
     cy.get('#crop-area-y').should('contain', '25')
     cy.percySnapshot()
   })
+
+  it('should debounce onCropComplete during a burst of window resizes', function () {
+    // let a real frame elapse so the ResizeObserver notification for this
+    // resize has actually been delivered (mirrors cy.setViewportStable above)
+    const settle = () =>
+      cy.window().then(
+        (win) =>
+          new Cypress.Promise((resolve) => {
+            win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
+          })
+      )
+    const countOnCropComplete = (spy) =>
+      spy.getCalls().filter((call) => call.args[0] === 'onCropComplete!').length
+
+    // let the initial mount settle first so its own onCropComplete call
+    // doesn't get counted as part of the resize burst below
+    settle()
+    cy.window().then((win) => {
+      cy.spy(win.console, 'log').as('consoleLog')
+    })
+    // freeze only the debounce timer itself (not rAF/Date), so ResizeObserver
+    // notifications are still delivered for real via the settle() waits below,
+    // but the resulting debounce timeout only fires when we call cy.tick
+    cy.clock(Date.now(), ['setTimeout', 'clearTimeout'])
+
+    // several resizes in a row, simulating dragging the window edge
+    cy.viewport(700, 600)
+    settle()
+    cy.viewport(800, 650)
+    settle()
+    cy.viewport(900, 700)
+    settle()
+
+    // right after the burst, onCropComplete should still be debounced (not fired yet)
+    cy.get('@consoleLog').should((spy) => {
+      expect(countOnCropComplete(spy)).to.eq(0)
+    })
+
+    // once the debounce window elapses, it should have fired exactly once for the whole burst
+    cy.tick(260)
+    cy.get('@consoleLog').should((spy) => {
+      expect(countOnCropComplete(spy)).to.eq(1)
+    })
+  })
 })

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -15,6 +15,11 @@ import {
 } from './helpers'
 import cssStyles from './styles.css?raw'
 
+// how long to wait after the last resize-triggered size recompute before
+// firing onCropComplete/onCropAreaChange, so a window/container resize
+// doesn't spam consumers with callbacks on every frame
+const RESIZE_EMIT_DEBOUNCE_TIME = 250
+
 export type CropperProps = {
   image?: string
   video?: string | VideoSrc[]
@@ -123,6 +128,7 @@ class Cropper extends React.Component<CropperProps, State> {
   rafDragTimeout: number | null = null
   rafPinchTimeout: number | null = null
   wheelTimer: number | null = null
+  resizeEmitTimer: number | null = null
   currentDoc: Document | null = typeof document !== 'undefined' ? document : null
   currentWindow: Window | null = typeof window !== 'undefined' ? window : null
   resizeObserver: ResizeObserver | null = null
@@ -148,7 +154,7 @@ class Cropper extends React.Component<CropperProps, State> {
       this.initResizeObserver()
       // only add window resize listener if ResizeObserver is not supported. Otherwise, it would be redundant
       if (typeof window.ResizeObserver === 'undefined') {
-        this.currentWindow.addEventListener('resize', this.computeSizes)
+        this.currentWindow.addEventListener('resize', this.onWindowResize)
       }
       this.props.zoomWithScroll &&
         this.containerRef.addEventListener('wheel', this.onWheel, { passive: false })
@@ -189,9 +195,12 @@ class Cropper extends React.Component<CropperProps, State> {
   componentWillUnmount() {
     if (!this.currentDoc || !this.currentWindow) return
     if (typeof window.ResizeObserver === 'undefined') {
-      this.currentWindow.removeEventListener('resize', this.computeSizes)
+      this.currentWindow.removeEventListener('resize', this.onWindowResize)
     }
     this.resizeObserver?.disconnect()
+    if (this.resizeEmitTimer) {
+      clearTimeout(this.resizeEmitTimer)
+    }
     if (this.containerRef) {
       this.containerRef.removeEventListener('gesturestart', this.preventZoomSafari)
     }
@@ -250,9 +259,13 @@ class Cropper extends React.Component<CropperProps, State> {
         isFirstResize = false // observe() is called on mount, we don't want to trigger a recompute on mount
         return
       }
-      this.computeSizes()
+      this.computeSizes(true)
     })
     this.resizeObserver.observe(this.containerRef)
+  }
+
+  onWindowResize = () => {
+    this.computeSizes(true)
   }
 
   // this is to prevent Safari on iOS >= 10 to zoom the page
@@ -348,7 +361,7 @@ class Cropper extends React.Component<CropperProps, State> {
     return this.props.objectFit
   }
 
-  computeSizes = () => {
+  computeSizes = (isResizeTriggered = false) => {
     const mediaRef = this.imageRef.current || this.videoRef.current
 
     if (mediaRef && this.containerRef) {
@@ -435,7 +448,7 @@ class Cropper extends React.Component<CropperProps, State> {
         this.props.onCropSizeChange && this.props.onCropSizeChange(cropSize)
       }
 
-      this.setState({ cropSize }, this.recomputeCropPosition)
+      this.setState({ cropSize }, () => this.recomputeCropPosition(isResizeTriggered))
 
       // pass crop size to parent
       if (this.props.setCropSize) {
@@ -728,7 +741,7 @@ class Cropper extends React.Component<CropperProps, State> {
     }
   }
 
-  recomputeCropPosition = () => {
+  recomputeCropPosition = (isResizeTriggered = false) => {
     if (!this.state.cropSize) return
 
     let adjustedCrop = this.props.crop
@@ -763,7 +776,24 @@ class Cropper extends React.Component<CropperProps, State> {
     this.previousCropSize = this.state.cropSize
 
     this.props.onCropChange(newPosition)
-    this.emitCropData()
+    if (isResizeTriggered) {
+      this.debouncedEmitCropData()
+    } else {
+      this.emitCropData()
+    }
+  }
+
+  // Same as emitCropData but debounced, so that a burst of resize-triggered
+  // recomputations (e.g. dragging the window edge) only fires
+  // onCropComplete/onCropAreaChange once, after the resize settles.
+  debouncedEmitCropData = () => {
+    if (!this.currentWindow) return
+    if (this.resizeEmitTimer) {
+      clearTimeout(this.resizeEmitTimer)
+    }
+    this.resizeEmitTimer = this.currentWindow.setTimeout(() => {
+      this.emitCropData()
+    }, RESIZE_EMIT_DEBOUNCE_TIME)
   }
 
   onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -259,13 +259,13 @@ class Cropper extends React.Component<CropperProps, State> {
         isFirstResize = false // observe() is called on mount, we don't want to trigger a recompute on mount
         return
       }
-      this.computeSizes(true)
+      this.computeSizes({ isResizeTriggered: true })
     })
     this.resizeObserver.observe(this.containerRef)
   }
 
   onWindowResize = () => {
-    this.computeSizes(true)
+    this.computeSizes({ isResizeTriggered: true })
   }
 
   // this is to prevent Safari on iOS >= 10 to zoom the page
@@ -361,7 +361,7 @@ class Cropper extends React.Component<CropperProps, State> {
     return this.props.objectFit
   }
 
-  computeSizes = (isResizeTriggered = false) => {
+  computeSizes = ({ isResizeTriggered = false }: { isResizeTriggered?: boolean } = {}) => {
     const mediaRef = this.imageRef.current || this.videoRef.current
 
     if (mediaRef && this.containerRef) {
@@ -448,7 +448,7 @@ class Cropper extends React.Component<CropperProps, State> {
         this.props.onCropSizeChange && this.props.onCropSizeChange(cropSize)
       }
 
-      this.setState({ cropSize }, () => this.recomputeCropPosition(isResizeTriggered))
+      this.setState({ cropSize }, () => this.recomputeCropPosition({ isResizeTriggered }))
 
       // pass crop size to parent
       if (this.props.setCropSize) {
@@ -746,7 +746,7 @@ class Cropper extends React.Component<CropperProps, State> {
     }
   }
 
-  recomputeCropPosition = (isResizeTriggered = false) => {
+  recomputeCropPosition = ({ isResizeTriggered = false }: { isResizeTriggered?: boolean } = {}) => {
     if (!this.state.cropSize) return
 
     let adjustedCrop = this.props.crop

--- a/src/Cropper.tsx
+++ b/src/Cropper.tsx
@@ -718,6 +718,11 @@ class Cropper extends React.Component<CropperProps, State> {
   }
 
   emitCropData = () => {
+    if (this.resizeEmitTimer) {
+      clearTimeout(this.resizeEmitTimer)
+      this.resizeEmitTimer = null
+    }
+
     const cropData = this.getCropData()
     if (!cropData) return
 


### PR DESCRIPTION
## Summary

Fixes #309.

`recomputeCropPosition` always calls `emitCropData()` unconditionally, and `computeSizes` now runs on every `ResizeObserver` tick. As a result, dragging the window/container edge fires `onCropComplete` and `onCropAreaChange` dozens of times during a single resize, even though the crop data at each intermediate tick isn't meaningful to consumers.

This PR debounces the `emitCropData()` call specifically for resize-triggered `computeSizes` calls (250ms), while every other trigger (rotation/aspect/zoom/cropSize prop changes, media load, drag/wheel/pinch interactions) keeps firing `onCropComplete` immediately as before. The crop area still updates visually in real time while resizing — only the completion callbacks are debounced.

## Changes

- `computeSizes(isResizeTriggered)` and `recomputeCropPosition(isResizeTriggered)` now take a flag, set to `true` only when called from the `ResizeObserver` callback or the legacy `window resize` fallback listener.
- Added `debouncedEmitCropData()`, mirroring the existing `wheelTimer` debounce pattern already used for `onInteractionStart`/`onInteractionEnd` on wheel zoom.
- Cleared the new timer in `componentWillUnmount` to avoid calling back into an unmounted component.

## Test plan

- [x] `pnpm unit` — 38 passing
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [x] Added a new Cypress e2e test (`should debounce onCropComplete during a burst of window resizes`) that triggers a burst of real resizes and asserts `onCropComplete` fires exactly once after the debounce window, instead of once per resize tick.
- [x] Verified the new test fails against the pre-fix code (reverted the source change locally, confirmed the test catches the regression) and passes with the fix.
- [x] Ran `pnpm start` and manually resized the demo window — crop area still tracks smoothly during the resize.