### PR TITLE
Link transform prop to advanced docs

### DIFF
--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -25,7 +25,7 @@ title: Props
 | `restrictPosition` | `boolean` |  | Restrict media position to cropper boundaries. Useful when `zoom < 1`. |
 | `initialCroppedAreaPercentages` | `{ width: number; height: number; x: number; y: number }` |  | Restore a crop from a previous `croppedArea` value. Preferred over pixels. |
 | `initialCroppedAreaPixels` | `{ width: number; height: number; x: number; y: number }` |  | Restore a crop from a previous `croppedAreaPixels` value. |
-| `transform` | `string` |  | Custom CSS transform for the media. |
+| `transform` | `string` |  | Custom CSS transform for the media. See [Custom transform](./advanced#custom-transform). |
 | `style` | `{ containerStyle?: object; mediaStyle?: object; cropAreaStyle?: object }` |  | Inline style overrides. |
 | `classes` | `{ containerClassName?: string; mediaClassName?: string; cropAreaClassName?: string }` |  | Custom class names. |
 | `mediaProps` | `object` |  | Props passed to the image or video element. |


### PR DESCRIPTION
## Summary

- Link the `transform` prop description to the existing Advanced docs section for custom transforms.

## Validation

- `pnpm type-check`
- `npm run build --prefix docs`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.1.1--canary.655.5ebff81.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@6.1.1--canary.655.5ebff81.0
  # or 
  yarn add react-easy-crop@6.1.1--canary.655.5ebff81.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
