### PR TITLE
Fix flaky resize debounce test

### DIFF
--- a/cypress/integration/basic_spec.js
+++ b/cypress/integration/basic_spec.js
@@ -72,46 +72,32 @@ describe('Basic assertions', function () {
   })
 
   it('should debounce onCropComplete during a burst of window resizes', function () {
-    // let a real frame elapse so the ResizeObserver notification for this
-    // resize has actually been delivered (mirrors cy.setViewportStable above)
-    const settle = () =>
-      cy.window().then(
-        (win) =>
-          new Cypress.Promise((resolve) => {
-            win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
-          })
-      )
     const countOnCropComplete = (spy) =>
       spy.getCalls().filter((call) => call.args[0] === 'onCropComplete!').length
 
-    // let the initial mount settle first so its own onCropComplete call
-    // doesn't get counted as part of the resize burst below
-    settle()
+    cy.get('#crop-area-x').should('contain', '15')
+
     cy.window().then((win) => {
       cy.spy(win.console, 'log').as('consoleLog')
     })
-    // freeze only the debounce timer itself (not rAF/Date), so ResizeObserver
-    // notifications are still delivered for real via the settle() waits below,
-    // but the resulting debounce timeout only fires when we call cy.tick
     cy.clock(Date.now(), ['setTimeout', 'clearTimeout'])
 
-    // several resizes in a row, simulating dragging the window edge
-    cy.viewport(700, 600)
-    settle()
-    cy.viewport(800, 650)
-    settle()
-    cy.viewport(900, 700)
-    settle()
-
-    // right after the burst, onCropComplete should still be debounced (not fired yet)
-    cy.get('@consoleLog').should((spy) => {
-      expect(countOnCropComplete(spy)).to.eq(0)
+    let callCountBeforeResize = 0
+    cy.get('@consoleLog').then((spy) => {
+      callCountBeforeResize = countOnCropComplete(spy)
     })
 
-    // once the debounce window elapses, it should have fired exactly once for the whole burst
+    cy.setViewportStable(700, 600)
+    cy.setViewportStable(800, 650)
+    cy.setViewportStable(900, 700)
+
+    cy.get('@consoleLog').should((spy) => {
+      expect(countOnCropComplete(spy)).to.eq(callCountBeforeResize)
+    })
+
     cy.tick(260)
     cy.get('@consoleLog').should((spy) => {
-      expect(countOnCropComplete(spy)).to.eq(1)
+      expect(countOnCropComplete(spy)).to.eq(callCountBeforeResize + 1)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Stabilize the resize debounce Cypress test by waiting for the initial crop UI to settle before spying
- Compare callback counts against a captured baseline instead of assuming zero calls
- Reuse `cy.setViewportStable` for resize delivery

## Root cause
The test waited two animation frames before installing the console spy, but image load, React updates, and ResizeObserver delivery can still land after that timing guess. That let the initial `onCropComplete` be counted as part of the resize burst.

## Validation
- `pnpm test`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.1--canary.658.13e41e0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@6.2.1--canary.658.13e41e0.0
  # or 
  yarn add react-easy-crop@6.2.1--canary.658.13e41e0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
