### PR TITLE
Fix docs workflow dependency install

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Using react-easy-crop@${latest_version}"
 
       - name: Install docs dependencies
-        run: pnpm --dir docs install --no-frozen-lockfile --ignore-scripts
+        run: pnpm --dir docs install --ignore-workspace --no-frozen-lockfile --ignore-scripts
 
       - name: Deploy docs to GitHub Pages
         run: pnpm --dir docs deploy


### PR DESCRIPTION
## Summary
- fix the docs deploy workflow install step to use `--ignore-workspace`
- ensures docs dependencies are installed into `docs/node_modules`, so `docusaurus deploy` can find the local binary

## Root cause
The failed run installed docs dependencies from inside the root pnpm workspace. The install completed, but `docs/node_modules/.bin/docusaurus` was missing, so the deploy step failed with `sh: 1: docusaurus: not found`.

Failed run: https://github.com/ValentinH/react-easy-crop/actions/runs/28928421399/job/85821389551

## Validation
- parsed `.github/workflows/deploy-docs.yml` as YAML
- reproduced the missing `docusaurus` binary with the old command in a clean archive of `origin/main`
- verified `pnpm --dir docs install --ignore-workspace --no-frozen-lockfile --ignore-scripts` creates `docs/node_modules/.bin/docusaurus`
- verified `pnpm --dir docs build` succeeds after the fixed install
