### PR TITLE
Update workflow actions to Node 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Use latest published package
         run: |

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: 24.x
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: pnpm-deps-${{ hashFiles('pnpm-lock.yaml') }}
@@ -35,7 +35,7 @@ jobs:
       - name: Create Build
         run: pnpm build
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: |
@@ -48,7 +48,7 @@ jobs:
         run: pnpm unit
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           start: pnpm start:ci
           record: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: pnpm-deps-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary
- update every workflow action that still targets Node.js 20
- move cache, artifact upload, pnpm setup, and Cypress actions to Node.js 24-compatible major versions

## Updated actions
- `pnpm/action-setup`: `v4` -> `v5`
- `actions/cache`: `v4` -> `v6`
- `actions/upload-artifact`: `v4` -> `v7`
- `cypress-io/github-action`: `v6` -> `v7`

## Validation
- parsed every workflow YAML file
- checked every referenced action in `.github/workflows` and confirmed `runs.using` is `node24`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.2--canary.661.b4832c4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-easy-crop@6.2.2--canary.661.b4832c4.0
  # or 
  yarn add react-easy-crop@6.2.2--canary.661.b4832c4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
